### PR TITLE
Make the Spirv output add the invariant flag if the position was marked as precise

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1001,6 +1001,14 @@ SpirvVariable *SpirvBuilder::addStageBuiltinVar(QualType type,
       loc, var, spv::Decoration::BuiltIn, {static_cast<uint32_t>(builtin)});
   mod->addDecoration(decor);
 
+  // If precise is enabled, Position is additionally decorated with Invariant.
+  if (isPrecise && builtin == spv::BuiltIn::Position)
+  {
+    auto *invariantDecor = new (context) SpirvDecoration(
+        loc, var, spv::Decoration::Invariant);
+    mod->addDecoration(invariantDecor);
+  }
+
   // Add variable to cache.
   builtinVars.emplace_back(storageClass, builtin, var);
 


### PR DESCRIPTION
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>